### PR TITLE
add change drive option to cd command

### DIFF
--- a/Make 7z from Files .cmd
+++ b/Make 7z from Files .cmd
@@ -1,4 +1,4 @@
 @echo off
-cd "%userprofile%\Documents\CustomContextMenu\"
+cd /d "%userprofile%\Documents\CustomContextMenu\"
 pwsh -NoProfile -ExecutionPolicy Unrestricted Create-7z.ps1 %*
 exit

--- a/Make 7z from Files with Password .cmd
+++ b/Make 7z from Files with Password .cmd
@@ -1,4 +1,4 @@
 @echo off
-cd "%userprofile%\Documents\CustomContextMenu\"
+cd /d "%userprofile%\Documents\CustomContextMenu\"
 pwsh -NoProfile -ExecutionPolicy Unrestricted Create-7zWithPassword.ps1 %*
 exit

--- a/Make List from Files .cmd
+++ b/Make List from Files .cmd
@@ -1,3 +1,4 @@
 @echo off
-pwsh -NoProfile -ExecutionPolicy Unrestricted "%userprofile%\Documents\CustomContextMenu\ClipBoardArg.ps1" %*
+cd /d "%userprofile%\Documents\CustomContextMenu\"
+pwsh -NoProfile -ExecutionPolicy Unrestricted ClipBoardArg.ps1 %*
 exit

--- a/Make Zip from Files .cmd
+++ b/Make Zip from Files .cmd
@@ -1,4 +1,4 @@
 @echo off
-cd "%userprofile%\Documents\CustomContextMenu\"
+cd /d "%userprofile%\Documents\CustomContextMenu\"
 pwsh -NoProfile -ExecutionPolicy Unrestricted Create-Zip.ps1 %*
 exit

--- a/Make Zip from Files with Password .cmd
+++ b/Make Zip from Files with Password .cmd
@@ -1,4 +1,4 @@
 @echo off
-cd "%userprofile%\Documents\CustomContextMenu\"
+cd /d "%userprofile%\Documents\CustomContextMenu\"
 pwsh -NoProfile -ExecutionPolicy Unrestricted Create-ZipWithPassword.ps1 %*
 exit


### PR DESCRIPTION
if click contextmenu on c drives or nas then success and d drive then failure.

because `cd` needs `/d` option.

so add `/d` to cd in all commands